### PR TITLE
Add Javascript fast functions

### DIFF
--- a/fast_functions.talon
+++ b/fast_functions.talon
@@ -1,0 +1,5 @@
+tag: user.fire_chicken_fast_functions
+-
+<user.fire_chicken_fast_functions>:
+    user.fire_chicken_call_function_inside(fire_chicken_fast_functions)
+prompt()

--- a/fire_chicken_language_specific.py
+++ b/fire_chicken_language_specific.py
@@ -6,6 +6,7 @@ module = Module()
 
 module.tag('fire_chicken_class_command', desc = 'Enables class command')
 module.tag('fire_chicken_programming_math_methods', desc = 'Enables math method command')
+module.tag('fire_chicken_fast_functions', desc = 'Enables fast functions')
 
 module.list('fire_chicken_programming_packages', desc = 'Active language list of programming packages')
 @module.capture(rule = '{user.fire_chicken_programming_packages}')
@@ -26,6 +27,11 @@ module.list('fire_chicken_math_methods', desc = 'Active language list of math me
 @module.capture(rule = '{user.fire_chicken_math_methods}')
 def fire_chicken_programming_math_method(m) -> str:
     return m.fire_chicken_math_methods
+
+module.list('fire_chicken_fast_functions', desc = 'Functions that can be dictated by stating a name for them with no prefix')
+@module.capture(rule = '{user.fire_chicken_fast_functions}')
+def fire_chicken_fast_functions(m) -> str:
+    return m.fire_chicken_fast_functions
 
 statement_ending = module.setting(
     'fire_chicken_statement_ending',

--- a/javascript.py
+++ b/javascript.py
@@ -1,0 +1,25 @@
+from talon import Module, Context
+
+module = Module()
+context = Context()
+context.matches = r'''
+tag: user.javascript
+'''
+
+context.lists['user.fire_chicken_fast_functions'] = {
+    'prompting' : 'prompt',
+    'pieces' : '.forEach',
+    'index of' : '.indexOf',
+    'last index of' : '.lastIndexOf',
+    'unshift' : '.unshift',
+    'shifting' : '.shift', 
+    'pushing' : '.push',
+    'popping' : '.pop',
+    'slicing' : '.slice',
+    'logging' : 'console.log',
+    'mapping' : '.map',
+    'filtering' : '.filter',
+    'everything' : '.every',
+    'summing' : '.some',
+    
+}

--- a/javascript.talon
+++ b/javascript.talon
@@ -1,12 +1,7 @@
 tag: user.javascript
 -
 tag(): user.c_style_programming
-
-
-logging | console log: 
-    insert("console.log")
-    user.generic_programming_insert_function_parentheses()
-    user.generic_programming_enter_function_parentheses_from_right()
+tag(): user.fire_chicken_fast_functions
 
 dot length: '.length'
 dot name: '.name'


### PR DESCRIPTION
Add javascript fast functions and the fast functions feature. This is for functions that are dictated without any preceding prefix.